### PR TITLE
Fix: 외부 API 장애 대비용 백업 API 세팅 및 Failover 로직 추가

### DIFF
--- a/src/main/java/com/codeit/weatherwear/domain/location/api/LocationApiClient.java
+++ b/src/main/java/com/codeit/weatherwear/domain/location/api/LocationApiClient.java
@@ -3,7 +3,7 @@ package com.codeit.weatherwear.domain.location.api;
 import com.codeit.weatherwear.domain.location.exception.KakaoGeoApiRequestException;
 import com.codeit.weatherwear.domain.location.exception.KakaoGeoApiResponseException;
 import com.codeit.weatherwear.domain.location.parser.LocationApiParser;
-import com.codeit.weatherwear.global.properties.LocationApiProperties;
+import com.codeit.weatherwear.domain.location.properties.LocationApiProperties;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;

--- a/src/main/java/com/codeit/weatherwear/domain/location/properties/LocationApiProperties.java
+++ b/src/main/java/com/codeit/weatherwear/domain/location/properties/LocationApiProperties.java
@@ -1,4 +1,4 @@
-package com.codeit.weatherwear.global.properties;
+package com.codeit.weatherwear.domain.location.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/src/main/java/com/codeit/weatherwear/domain/weather/api/WeatherApiClient.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/api/WeatherApiClient.java
@@ -1,16 +1,14 @@
 package com.codeit.weatherwear.domain.weather.api;
 
+import com.codeit.weatherwear.domain.weather.api.strategy.WeatherApiStrategy;
+import com.codeit.weatherwear.domain.weather.config.WeatherApiProperties;
+import com.codeit.weatherwear.domain.weather.config.WeatherApiProperties.ApiEndpoint;
 import com.codeit.weatherwear.domain.weather.exception.WeatherApiRequestException;
 import com.codeit.weatherwear.domain.weather.exception.WeatherApiResponseException;
-import com.codeit.weatherwear.global.properties.WeatherApiProperties;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.net.URI;
 import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Comparator;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -24,8 +22,9 @@ import org.springframework.stereotype.Component;
 public class WeatherApiClient {
 
   private final WeatherApiProperties apiProperties;
-
   private final HttpClient httpClient;
+  private final ObjectMapper mapper;
+  private final List<WeatherApiStrategy> strategies;  // API 별 전략
 
   /**
    * 단기 예보 API에 데이터를 요청하여 응답을 받아와 리턴한다.
@@ -37,48 +36,49 @@ public class WeatherApiClient {
    * @param ny       예보 지점 Y좌표
    * @return API 응답 데이터(ResponseBody)
    */
-  public String fetchWeatherData(
-      ObjectMapper mapper, String baseDate, String baseTime, int nx, int ny) {
-    // 기본 파라미터 세팅
-    String REQUEST_PARAM_DATA_TYPE = "JSON";
-    int REQUEST_PARAM_NUM_OF_ROWS = 1500;
+  public String fetchWeatherData(String baseDate, String baseTime, int nx, int ny) {
+    // 우선 순위 순으로 엔드포인트 정렬
+    List<ApiEndpoint> activeEndpoints = apiProperties.endPoints().stream()
+        .filter(WeatherApiProperties.ApiEndpoint::enabled)
+        .sorted(Comparator.comparingInt(WeatherApiProperties.ApiEndpoint::priority))
+        .toList();
 
-    // 요청 URL 세팅
-    String requestUrl = String.format(
-        "%s?serviceKey=%s&numOfRows=%d&dataType=%s&base_date=%s&base_time=%s&nx=%d&ny=%d",
-        apiProperties.apiUrl(), apiProperties.apiServiceKey(),
-        REQUEST_PARAM_NUM_OF_ROWS, REQUEST_PARAM_DATA_TYPE, baseDate, baseTime, nx, ny
-    );
-
-    // HttpClient 세팅 및 요청 세팅
-    HttpRequest request = HttpRequest.newBuilder()
-        .uri(URI.create(requestUrl))
-        .GET()
-        .build();
-
-    try {
-      HttpResponse<String> response = httpClient.send(request, BodyHandlers.ofString());
-      String resultCode = extractResultCode(mapper, response.body());
-      // 응답 코드가 00이 아니면 비정상적인 응답 (오류)
-      if (!"00".equals(resultCode)) {
-        log.warn("Weather Api Response Invalid");
-        throw new WeatherApiResponseException(resultCode);
-      }
-      // 응답 Body 전달
-      return response.body();
-    } catch (IOException | InterruptedException e) {
-      log.info("url: {}", requestUrl);
-      log.error("Weather Api Request Invalid - cause: {}\nmessage: {}", e.getCause(),
-          e.getMessage());
+    if (activeEndpoints.isEmpty()) {
+      // todo: 요청 할 수 있는 엔드포인트가 없다는 예외 추가
       throw new WeatherApiRequestException();
     }
+
+    // 마지막에 발생한 예외 기록용 - 어디까지 잘못됐나 추적
+    Exception lastException = null;
+
+    for (ApiEndpoint endpoint : activeEndpoints) {
+      try {
+        log.info("Attempting Weather API: {} (priority: {})", endpoint.name(), endpoint.priority());
+
+        WeatherApiStrategy strategy = findStrategy(endpoint.name());
+        String responseBody = strategy.fetchData(httpClient, mapper, endpoint, baseDate, baseTime,
+            nx, ny);
+
+        log.info("Successfully fetched weather data from: {}", endpoint.name());
+        return responseBody;
+
+      } catch (WeatherApiResponseException | WeatherApiRequestException we) {
+        log.warn("Failed to fetch from {}: {}", endpoint.name(), we.getMessage());
+        lastException = we;
+      }
+    }
+
+    log.error("All weather forecast API endpoints failed");
+    // todo: 예외 처리 추후 조심해야 함
+    throw new WeatherApiRequestException("All Configured weather APIs failed", lastException);
   }
 
-  private String extractResultCode(ObjectMapper mapper, String responseBody)
-      throws IOException {
-    // Header의 resultCode 필드 속 값 String 형태로 추출
-    JsonNode root = mapper.readTree(responseBody);
-    return root.path("response").path("header").path("resultCode").asText();
+  private WeatherApiStrategy findStrategy(String apiName) {
+    return strategies.stream()
+        .filter(s -> s.supports(apiName))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException(
+            "No Strategy found for Weather Forecast API: " + apiName));
   }
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/api/WeatherApiClient.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/api/WeatherApiClient.java
@@ -3,6 +3,7 @@ package com.codeit.weatherwear.domain.weather.api;
 import com.codeit.weatherwear.domain.weather.api.strategy.WeatherApiStrategy;
 import com.codeit.weatherwear.domain.weather.config.WeatherApiProperties;
 import com.codeit.weatherwear.domain.weather.config.WeatherApiProperties.ApiEndpoint;
+import com.codeit.weatherwear.domain.weather.exception.UseStrategyNotFoundException;
 import com.codeit.weatherwear.domain.weather.exception.WeatherApiRequestException;
 import com.codeit.weatherwear.domain.weather.exception.WeatherApiResponseException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,8 +45,7 @@ public class WeatherApiClient {
         .toList();
 
     if (activeEndpoints.isEmpty()) {
-      // todo: 요청 할 수 있는 엔드포인트가 없다는 예외 추가
-      throw new WeatherApiRequestException();
+      throw new UseStrategyNotFoundException();
     }
 
     // 마지막에 발생한 예외 기록용 - 어디까지 잘못됐나 추적
@@ -69,7 +69,6 @@ public class WeatherApiClient {
     }
 
     log.error("All weather forecast API endpoints failed");
-    // todo: 예외 처리 추후 조심해야 함
     throw new WeatherApiRequestException("All Configured weather APIs failed", lastException);
   }
 
@@ -77,8 +76,7 @@ public class WeatherApiClient {
     return strategies.stream()
         .filter(s -> s.supports(apiName))
         .findFirst()
-        .orElseThrow(() -> new IllegalStateException(
-            "No Strategy found for Weather Forecast API: " + apiName));
+        .orElseThrow(() -> new UseStrategyNotFoundException(apiName));
   }
 
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/api/parser/WeatherApiParser.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/api/parser/WeatherApiParser.java
@@ -1,4 +1,4 @@
-package com.codeit.weatherwear.domain.weather.parser;
+package com.codeit.weatherwear.domain.weather.api.parser;
 
 import com.codeit.weatherwear.domain.weather.entity.WeatherApiData;
 import com.codeit.weatherwear.domain.weather.entity.WeatherApiDataId;
@@ -12,9 +12,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class WeatherApiParser {
 
   private static final Set<String> TARGET_CATEGORIES = Set.of(
@@ -25,18 +27,18 @@ public class WeatherApiParser {
       "WSD"   // 풍속
   );
 
+  private final ObjectMapper objectMapper;
+
   /**
    * 단기예보 API JSON 응답을 파싱하여 WeatherApiData 리스트로 변환한 뒤,<br>예보 날짜(fcstDate) → 예보 시간(fcstTime) 기준으로
    * 그룹핑하여 반환
    *
-   * @param mapper       Jackson ObjectMapper
    * @param responseBody 단기예보 API 응답의 JSON body 문자열
    * @return 예보 날짜 → 예보 시간 → 해당 시간대 예보 데이터 리스트로 구성된 Map
    */
-  public Map<String, Map<String, List<WeatherApiData>>> parse(ObjectMapper mapper,
-      String responseBody) {
+  public Map<String, Map<String, List<WeatherApiData>>> parse(String responseBody) {
     try {
-      JsonNode root = mapper.readTree(responseBody); // 전체 JSON
+      JsonNode root = objectMapper.readTree(responseBody); // 전체 JSON
       JsonNode itemsNode = root.path("response").path("body").path("items").path("item");
 
       // 엔티티 저장할 리스트

--- a/src/main/java/com/codeit/weatherwear/domain/weather/api/strategy/KoreanWeatherApiStrategy.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/api/strategy/KoreanWeatherApiStrategy.java
@@ -64,7 +64,6 @@ public abstract class KoreanWeatherApiStrategy implements WeatherApiStrategy {
       log.info("url: {}", requestUrl);
       log.error("Weather Api Request Invalid - cause: {}\nmessage: {}", e.getCause(),
           e.getMessage());
-      throw new WeatherApiRequestException();
       throw new WeatherApiRequestException("Weather API request failed", e);
     }
   }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/api/strategy/KoreanWeatherApiStrategy.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/api/strategy/KoreanWeatherApiStrategy.java
@@ -7,10 +7,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -52,11 +54,18 @@ public abstract class KoreanWeatherApiStrategy implements WeatherApiStrategy {
       }
       // 응답 Body 전달
       return response.body();
-    } catch (IOException | InterruptedException e) {
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      log.info("url: {}", requestUrl);
+      log.error("Weather Api Request Invalid - cause: {}\nmessage: {}", e.getCause(),
+          e.getMessage());
+      throw new WeatherApiRequestException("Weather API request interrupted", e);
+    } catch (IOException e) {
       log.info("url: {}", requestUrl);
       log.error("Weather Api Request Invalid - cause: {}\nmessage: {}", e.getCause(),
           e.getMessage());
       throw new WeatherApiRequestException();
+      throw new WeatherApiRequestException("Weather API request failed", e);
     }
   }
 
@@ -64,7 +73,8 @@ public abstract class KoreanWeatherApiStrategy implements WeatherApiStrategy {
       int ny) {
     return String.format(
         "%s?%s=%s&numOfRows=%d&dataType=%s&base_date=%s&base_time=%s&nx=%d&ny=%d",
-        endpoint.apiUrl(), getServiceKeyParamName(), endpoint.apiServiceKey(),
+        endpoint.apiUrl(), getServiceKeyParamName(),
+        URLEncoder.encode(endpoint.apiServiceKey(), StandardCharsets.UTF_8),
         NUM_OF_ROWS, DATA_TYPE, baseDate, baseTime, nx, ny
     );
   }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/api/strategy/KoreanWeatherApiStrategy.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/api/strategy/KoreanWeatherApiStrategy.java
@@ -1,0 +1,78 @@
+package com.codeit.weatherwear.domain.weather.api.strategy;
+
+import com.codeit.weatherwear.domain.weather.config.WeatherApiProperties.ApiEndpoint;
+import com.codeit.weatherwear.domain.weather.exception.WeatherApiRequestException;
+import com.codeit.weatherwear.domain.weather.exception.WeatherApiResponseException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 한국 API (공공 데이터 포탈/기상청 Open API 로직)
+ * <p>
+ * API Key 파라미터명 제외하고 모두 동일하기에 추상 클래스를 통해 추상화하고 <br> 각 API별 구현체에서는 둘이 다른 부분만 조정할 수 있도록 함
+ * <p>
+ * 중복 로직 제거 목적
+ */
+@Slf4j
+public abstract class KoreanWeatherApiStrategy implements WeatherApiStrategy {
+
+  private static final String DATA_TYPE = "JSON";
+  private static final int NUM_OF_ROWS = 1500;
+  private static final String SUCCESS_RESULT_CODE = "00";
+
+  protected abstract String getServiceKeyParamName();
+
+  @Override
+  public String fetchData(HttpClient httpClient, ObjectMapper mapper, ApiEndpoint endpoint,
+      String baseDate, String baseTime, int nx, int ny)
+      throws WeatherApiRequestException, WeatherApiResponseException {
+    // 요청 URL 세팅
+    String requestUrl = buildRequestUrl(endpoint, baseDate, baseTime, nx, ny);
+
+    // HttpClient 세팅 및 요청 세팅
+    HttpRequest request = HttpRequest.newBuilder()
+        .uri(URI.create(requestUrl))
+        .GET()
+        .build();
+
+    try {
+      HttpResponse<String> response = httpClient.send(request, BodyHandlers.ofString());
+      String resultCode = extractResultCode(mapper, response.body());
+      // 응답 코드가 00이 아니면 비정상적인 응답 (오류)
+      if (!SUCCESS_RESULT_CODE.equals(resultCode)) {
+        log.warn("Weather Api Response Invalid");
+        throw new WeatherApiResponseException(resultCode);
+      }
+      // 응답 Body 전달
+      return response.body();
+    } catch (IOException | InterruptedException e) {
+      log.info("url: {}", requestUrl);
+      log.error("Weather Api Request Invalid - cause: {}\nmessage: {}", e.getCause(),
+          e.getMessage());
+      throw new WeatherApiRequestException();
+    }
+  }
+
+  private String buildRequestUrl(ApiEndpoint endpoint, String baseDate, String baseTime, int nx,
+      int ny) {
+    return String.format(
+        "%s?%s=%s&numOfRows=%d&dataType=%s&base_date=%s&base_time=%s&nx=%d&ny=%d",
+        endpoint.apiUrl(), getServiceKeyParamName(), endpoint.apiServiceKey(),
+        NUM_OF_ROWS, DATA_TYPE, baseDate, baseTime, nx, ny
+    );
+  }
+
+  private String extractResultCode(ObjectMapper mapper, String responseBody)
+      throws IOException {
+    // Header의 resultCode 필드 속 값 String 형태로 추출
+    JsonNode root = mapper.readTree(responseBody);
+    return root.path("response").path("header").path("resultCode").asText();
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/weather/api/strategy/WeatherApiStrategy.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/api/strategy/WeatherApiStrategy.java
@@ -1,0 +1,22 @@
+package com.codeit.weatherwear.domain.weather.api.strategy;
+
+import com.codeit.weatherwear.domain.weather.config.WeatherApiProperties.ApiEndpoint;
+import com.codeit.weatherwear.domain.weather.exception.WeatherApiRequestException;
+import com.codeit.weatherwear.domain.weather.exception.WeatherApiResponseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.http.HttpClient;
+
+public interface WeatherApiStrategy {
+
+  boolean supports(String apiName);
+
+  String fetchData(
+      HttpClient httpClient,
+      ObjectMapper mapper,
+      ApiEndpoint endpoint,
+      String baseDate,
+      String baseTime,
+      int nx,
+      int ny
+  ) throws WeatherApiRequestException, WeatherApiResponseException;
+}

--- a/src/main/java/com/codeit/weatherwear/domain/weather/api/strategy/impl/KmaWeatherApiStrategy.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/api/strategy/impl/KmaWeatherApiStrategy.java
@@ -1,0 +1,36 @@
+package com.codeit.weatherwear.domain.weather.api.strategy.impl;
+
+import com.codeit.weatherwear.domain.weather.api.strategy.KoreanWeatherApiStrategy;
+import com.codeit.weatherwear.domain.weather.api.strategy.WeatherApiStrategy;
+import com.codeit.weatherwear.domain.weather.config.WeatherApiProperties.ApiEndpoint;
+import com.codeit.weatherwear.domain.weather.exception.WeatherApiRequestException;
+import com.codeit.weatherwear.domain.weather.exception.WeatherApiResponseException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 기상자료개방포털(기상청)의 날씨 예보 API 전략
+ */
+@Slf4j
+@Component
+public class KmaWeatherApiStrategy extends KoreanWeatherApiStrategy {
+
+  @Override
+  protected String getServiceKeyParamName() {
+    return "authKey";
+  }
+
+  @Override
+  public boolean supports(String apiName) {
+    return apiName.startsWith("kma-");
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/weather/api/strategy/impl/OpenWeatherApiStrategy.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/api/strategy/impl/OpenWeatherApiStrategy.java
@@ -1,0 +1,23 @@
+package com.codeit.weatherwear.domain.weather.api.strategy.impl;
+
+import com.codeit.weatherwear.domain.weather.api.strategy.KoreanWeatherApiStrategy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 공공 데이터 포털의 날씨 예보 API 전략
+ */
+@Slf4j
+@Component
+public class OpenWeatherApiStrategy extends KoreanWeatherApiStrategy {
+
+  @Override
+  protected String getServiceKeyParamName() {
+    return "serviceKey";
+  }
+
+  @Override
+  public boolean supports(String apiName) {
+    return apiName.startsWith("open-");
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/weather/config/WeatherApiProperties.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/config/WeatherApiProperties.java
@@ -1,0 +1,13 @@
+package com.codeit.weatherwear.domain.weather.config;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "weather")
+public record WeatherApiProperties(List<ApiEndpoint> endPoints) {
+
+  public record ApiEndpoint(String name, String apiUrl, String apiServiceKey, int priority,
+                            boolean enabled) {
+
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/weather/exception/UseStrategyNotFoundException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/exception/UseStrategyNotFoundException.java
@@ -1,0 +1,16 @@
+package com.codeit.weatherwear.domain.weather.exception;
+
+import com.codeit.weatherwear.global.exception.CustomException;
+import com.codeit.weatherwear.global.exception.ErrorCode;
+import java.util.Map;
+
+public class UseStrategyNotFoundException extends CustomException {
+
+  public UseStrategyNotFoundException() {
+    super(ErrorCode.WEATHER_REQUEST_API_NOT_FOUND);
+  }
+
+  public UseStrategyNotFoundException(String apiName) {
+    super(ErrorCode.WEATHER_REQUEST_API_NOT_FOUND, Map.of("apiName", apiName));
+  }
+}

--- a/src/main/java/com/codeit/weatherwear/domain/weather/exception/WeatherApiRequestException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/exception/WeatherApiRequestException.java
@@ -8,4 +8,8 @@ public class WeatherApiRequestException extends CustomException {
   public WeatherApiRequestException() {
     super(ErrorCode.WEATHER_API_REQUEST_ERROR);
   }
+
+  public WeatherApiRequestException(String msg, Exception lastException) {
+    super(ErrorCode.WEATHER_API_REQUEST_ERROR);
+  }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/exception/WeatherApiRequestException.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/exception/WeatherApiRequestException.java
@@ -2,6 +2,7 @@ package com.codeit.weatherwear.domain.weather.exception;
 
 import com.codeit.weatherwear.global.exception.CustomException;
 import com.codeit.weatherwear.global.exception.ErrorCode;
+import java.util.Map;
 
 public class WeatherApiRequestException extends CustomException {
 
@@ -10,6 +11,6 @@ public class WeatherApiRequestException extends CustomException {
   }
 
   public WeatherApiRequestException(String msg, Exception lastException) {
-    super(ErrorCode.WEATHER_API_REQUEST_ERROR);
+    super(ErrorCode.WEATHER_API_REQUEST_ERROR, Map.of("message", msg, "lastException", lastException));
   }
 }

--- a/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherConvertServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherConvertServiceImpl.java
@@ -61,7 +61,7 @@ public class WeatherConvertServiceImpl implements WeatherConvertService {
   /**
    * @param fcstDate       예보 날짜 (yyyyMMdd)
    * @param timeMap        시간별 WeatherApiData 리스트 맵
-   * @param groupedApiData 카테고리별로 그룹화된 WeatherApiData 맵 (fcstDate -> fcstTime -> data)
+   * @param compareWeather Weather 엔티티
    * @param location       위치 정보
    * @return 변환된 Weather 객체(Optional), 변환 불가 시 Optional.empty()
    */

--- a/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherFetchServiceImpl.java
+++ b/src/main/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherFetchServiceImpl.java
@@ -3,13 +3,12 @@ package com.codeit.weatherwear.domain.weather.service.impl;
 import com.codeit.weatherwear.domain.location.entity.Location;
 import com.codeit.weatherwear.domain.location.service.LocationService;
 import com.codeit.weatherwear.domain.weather.api.WeatherApiClient;
+import com.codeit.weatherwear.domain.weather.api.parser.WeatherApiParser;
 import com.codeit.weatherwear.domain.weather.entity.Weather;
 import com.codeit.weatherwear.domain.weather.entity.WeatherApiData;
-import com.codeit.weatherwear.domain.weather.parser.WeatherApiParser;
 import com.codeit.weatherwear.domain.weather.repository.WeatherRepository;
 import com.codeit.weatherwear.domain.weather.service.WeatherConvertService;
 import com.codeit.weatherwear.domain.weather.service.WeatherFetchService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -87,16 +86,15 @@ public class WeatherFetchServiceImpl implements WeatherFetchService {
 
     log.info("baseDate: {}, baseTime: {}", baseDate, baseTime);
 
-    ObjectMapper mapper = new ObjectMapper();
     // 위치 엔티티 조회, 존재하지 않을 시 생성
     Location location = locationService.findOrCreateByGeoPoint(latitude, longitude);
 
     // 단기 예보 API 요청 후 응답 Body 값 반환
-    String responseBody = weatherApiClient.fetchWeatherData(mapper, baseDate, baseTime,
-        location.getX(), location.getY());
+    String responseBody = weatherApiClient.fetchWeatherData(baseDate, baseTime, location.getX(),
+        location.getY());
 
     // 응답 Body 값 파싱하여 Map[예보 날짜,Map[예보 타입(POP 등), 예보 RAW 데이터]] 으로 반환
-    Map<String, Map<String, List<WeatherApiData>>> parsedWeatherApi = weatherApiParser.parse(mapper,
+    Map<String, Map<String, List<WeatherApiData>>> parsedWeatherApi = weatherApiParser.parse(
         responseBody);
 
     // 파싱한 데이터를 Weather 엔티티에 맞게 변환

--- a/src/main/java/com/codeit/weatherwear/global/exception/ErrorCode.java
+++ b/src/main/java/com/codeit/weatherwear/global/exception/ErrorCode.java
@@ -2,7 +2,6 @@ package com.codeit.weatherwear.global.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.actuate.autoconfigure.observation.ObservationProperties.Http;
 import org.springframework.http.HttpStatus;
 
 /**
@@ -52,6 +51,7 @@ public enum ErrorCode {
   WEATHER_API_PARSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "단기 예보 JSON 파싱 실패",
       "단기 예보 JSON 파싱 중 오류가 발생하여 실패하였습니다."),
   WEATHER_NOT_FOUND(HttpStatus.NOT_FOUND, "날씨 확인 실패", "존재하지 않는 날씨입니다."),
+  WEATHER_REQUEST_API_NOT_FOUND(HttpStatus.NOT_FOUND, "요청 가능한 API 없음", "요청할 수 있는 API가 존재하지 않습니다."),
 
   // SECURITY
   JWTSESSION_NOT_FOUND(HttpStatus.UNAUTHORIZED, "인증 정보 확인 실패", "토큰이 만료되거나 로그아웃되었습니다."),

--- a/src/main/java/com/codeit/weatherwear/global/properties/WeatherApiProperties.java
+++ b/src/main/java/com/codeit/weatherwear/global/properties/WeatherApiProperties.java
@@ -1,8 +1,0 @@
-package com.codeit.weatherwear.global.properties;
-
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
-@ConfigurationProperties(prefix = "weather")
-public record WeatherApiProperties(String apiUrl, String apiServiceKey) {
-
-}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,10 +88,19 @@ server:
   forward-headers-strategy: native
 
 weather:
-  api-url: ${WEATHER_INFO_API_URL}
-  api-service-key: ${WEATHER_INFO_SERVICE_KEY}
   batch:
     chunk-size: 100
+  end-points:
+    - name: open-api  # open data 포탈
+      api-url: ${WEATHER_INFO_API_URL}
+      api-service-key: ${WEATHER_INFO_SERVICE_KEY}
+      priority: 1
+      enabled: true
+    - name: kma-api  # 기상청 오픈 API
+      api-url: ${WEATHER_INFO_KMA_API_URL}
+      api-service-key: ${WEATHER_INFO_KMA_SERVICE_KEY}
+      priority: 2
+      enabled: true
 
 location:
   api-url: ${LOCATION_API_URL}

--- a/src/test/java/com/codeit/weatherwear/domain/location/api/LocationApiClientTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/location/api/LocationApiClientTest.java
@@ -9,7 +9,7 @@ import static org.mockito.BDDMockito.given;
 import com.codeit.weatherwear.domain.location.exception.KakaoGeoApiRequestException;
 import com.codeit.weatherwear.domain.location.exception.KakaoGeoApiResponseException;
 import com.codeit.weatherwear.domain.location.parser.LocationApiParser;
-import com.codeit.weatherwear.global.properties.LocationApiProperties;
+import com.codeit.weatherwear.domain.location.properties.LocationApiProperties;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;

--- a/src/test/java/com/codeit/weatherwear/domain/weather/api/WeatherApiClientTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/weather/api/WeatherApiClientTest.java
@@ -8,7 +8,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.codeit.weatherwear.domain.weather.exception.WeatherApiRequestException;
 import com.codeit.weatherwear.domain.weather.exception.WeatherApiResponseException;
-import com.codeit.weatherwear.global.properties.WeatherApiProperties;
+import com.codeit.weatherwear.domain.weather.config.WeatherApiProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.http.HttpClient;

--- a/src/test/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherFetchServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherwear/domain/weather/service/impl/WeatherFetchServiceImplTest.java
@@ -14,7 +14,7 @@ import com.codeit.weatherwear.domain.location.service.LocationService;
 import com.codeit.weatherwear.domain.weather.api.WeatherApiClient;
 import com.codeit.weatherwear.domain.weather.entity.Weather;
 import com.codeit.weatherwear.domain.weather.entity.WeatherApiData;
-import com.codeit.weatherwear.domain.weather.parser.WeatherApiParser;
+import com.codeit.weatherwear.domain.weather.api.parser.WeatherApiParser;
 import com.codeit.weatherwear.domain.weather.repository.WeatherRepository;
 import com.codeit.weatherwear.domain.weather.service.WeatherConvertService;
 import com.fasterxml.jackson.databind.ObjectMapper;


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#1

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [x] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

refactor/1/fix-weather-connect -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

날씨 API Failover 로직 추가 및 Strategy 패턴 적용

- Chain of Responsibility 패턴으로 다중 API 엔드포인트 지원
- Strategy 패턴으로 API 제공자별 로직 분리
- ObjectMapper를 Spring Bean 주입으로 변경하여 성능 개선
- 커스텀 예외 등을 통한 예외 처리 세분화

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

### ✅ PR 올리기 전 체크리스트

- [x] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [x] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [x] 필요한 경우 관련 문서를 업데이트했습니다.

### 📽️ 참고 자료
[기상 예보 외부 API 대체 로직 추가 리포트](https://www.notion.so/API-28897c15da0880f9bd1dcf8481aeabd2?source=copy_link)